### PR TITLE
Added Email tag command

### DIFF
--- a/src/main/java/seedu/duke/CommandParser.java
+++ b/src/main/java/seedu/duke/CommandParser.java
@@ -570,7 +570,7 @@ public class CommandParser {
         ArrayList<String> tagList = new ArrayList<>();
         for (Option option : optionList) {
             if (option.getKey().equals("tag")) {
-                tagList.add(option.getValue());
+                tagList.add(option.getValue().strip());
             }
         }
         return tagList;

--- a/src/main/java/seedu/duke/email/EmailFormatParser.java
+++ b/src/main/java/seedu/duke/email/EmailFormatParser.java
@@ -28,14 +28,15 @@ public class EmailFormatParser {
      * @throws EmailParsingException the exception of the failure of the response parsing
      */
     public static EmailList parseFetchResponse(String response) throws EmailParsingException {
-        Duke.getUI().showDebug(response);
+        //Duke.getUI().showDebug(response);
         EmailList emailList = new EmailList();
         try {
             JSONObject responseJson = new JSONObject(response);
             JSONArray emailJsonArray = responseJson.getJSONArray("value");
             for (int i = 0; i < emailJsonArray.length(); i++) {
                 JSONObject emailJson = emailJsonArray.getJSONObject(i);
-                emailList.add(parseComponentsToEmail(emailJson));
+                Email email = parseComponentsToEmail(emailJson);
+                emailList.add(email);
             }
         } catch (JSONException e) {
             throw new EmailParsingException("Email fetch response failed to parse");

--- a/src/main/java/seedu/duke/email/EmailList.java
+++ b/src/main/java/seedu/duke/email/EmailList.java
@@ -48,7 +48,7 @@ public class EmailList extends ArrayList<Email> {
         for (String tag : tags) {
             email.addTag(tag);
         }
-        String responseMsg = "Added tags: " + tags.toString() + "\nto email: " + email.getSubject();
+        String responseMsg = "Tags added: " + tags.toString() + "\nto email: " + email.getSubject();
         return responseMsg;
     }
 }

--- a/src/main/java/seedu/duke/email/EmailList.java
+++ b/src/main/java/seedu/duke/email/EmailList.java
@@ -35,10 +35,7 @@ public class EmailList extends ArrayList<Email> {
      * @throws CommandParser.UserInputException thrown when index parsing failed or out of range
      * @throws IOException                      if fails to load the filepath or open the browser.
      */
-    public String[] show(int index) throws CommandParser.UserInputException, IOException {
-        if (index < 0 || index >= this.size()) {
-            throw new CommandParser.UserInputException("Invalid index");
-        }
+    public String[] show(int index) {
         Email email = this.get(index);
         String emailContent = email.getBody();
         String responseMsg = "Showing email in browser: " + email.getSubject();
@@ -46,4 +43,12 @@ public class EmailList extends ArrayList<Email> {
         return responseArray;
     }
 
+    public String addTags(int index, ArrayList<String> tags) {
+        Email email = this.get(index);
+        for (String tag : tags) {
+            email.addTag(tag);
+        }
+        String responseMsg = "Added tags: " + tags.toString() + "\nto email: " + email.getSubject();
+        return responseMsg;
+    }
 }

--- a/src/main/java/seedu/duke/email/EmailStorage.java
+++ b/src/main/java/seedu/duke/email/EmailStorage.java
@@ -96,7 +96,14 @@ public class EmailStorage {
         for (Email serverEmail : serverEmailList) {
             boolean exist = false;
             for (Email localEmail : Duke.getEmailList()) {
-                if (localEmail.getSubject().equals(serverEmail.getSubject())) {
+                // Check existence of serverEmail in localEmail by comparing the email subject and
+                // ReceivedDateTime.
+                // If not checked by ReceivedDateTime, emails with same subject is filtered out from being
+                // added to emailList.
+                boolean isEqualSubject = localEmail.getSubject().equals(serverEmail.getSubject());
+                boolean isEqualDateTime =
+                        localEmail.getReceivedDateTime().equals(serverEmail.getReceivedDateTime());
+                if (isEqualSubject && isEqualDateTime) {
                     exist = true;
                     break;
                 }

--- a/src/main/java/seedu/duke/email/EmailStorage.java
+++ b/src/main/java/seedu/duke/email/EmailStorage.java
@@ -274,6 +274,8 @@ public class EmailStorage {
 
                 String[] tags = splitString[1].strip().split("#");
                 for (String tag : tags) {
+                    if (tag.strip().equals("")) continue;
+                    System.out.println(tag);
                     email.addTag(tag.strip());
                 }
                 emailList.add(email);

--- a/src/main/java/seedu/duke/email/command/EmailShowCommand.java
+++ b/src/main/java/seedu/duke/email/command/EmailShowCommand.java
@@ -18,17 +18,10 @@ public class EmailShowCommand extends Command {
 
     @Override
     public boolean execute() {
-        try {
-            String[] parsedMsg = emailList.show(index);
-            responseMsg = parsedMsg[0];
-            Duke.getUI().showResponse(parsedMsg[0]);
-            Duke.getUI().setEmailContent(parsedMsg[1]);
-            return true;
-        } catch (CommandParser.UserInputException | IOException e) {
-            if (!silent) {
-                Duke.getUI().showError(e.toString());
-            }
-            return false;
-        }
+        String[] parsedMsg = emailList.show(index);
+        responseMsg = parsedMsg[0];
+        Duke.getUI().showResponse(parsedMsg[0]);
+        Duke.getUI().setEmailContent(parsedMsg[1]);
+        return true;
     }
 }

--- a/src/main/java/seedu/duke/email/command/EmailTagCommand.java
+++ b/src/main/java/seedu/duke/email/command/EmailTagCommand.java
@@ -1,0 +1,26 @@
+package seedu.duke.email.command;
+
+import seedu.duke.Duke;
+import seedu.duke.common.command.Command;
+import seedu.duke.email.EmailList;
+
+import java.util.ArrayList;
+
+public class EmailTagCommand extends Command {
+    private EmailList emailList;
+    private int index;
+    private ArrayList<String> tags;
+
+    public EmailTagCommand(EmailList emailList, int index, ArrayList<String> tags) {
+        this.emailList = emailList;
+        this.index = index;
+        this.tags = tags;
+    }
+
+    @Override
+    public boolean execute() {
+        String responseMsg = emailList.addTags(index, tags);
+        Duke.getUI().showResponse(responseMsg);
+        return true;
+    }
+}

--- a/src/main/java/seedu/duke/email/entity/Email.java
+++ b/src/main/java/seedu/duke/email/entity/Email.java
@@ -66,6 +66,10 @@ public class Email {
         this.tags.add(tag);
     }
 
+    public ArrayList<String> getTags() {
+        return this.tags;
+    }
+
     public String getRawJson() {
         return this.rawJson;
     }

--- a/src/main/java/seedu/duke/email/entity/Email.java
+++ b/src/main/java/seedu/duke/email/entity/Email.java
@@ -60,10 +60,10 @@ public class Email {
     }
 
     public void addTag(String tag) {
-        if (this.tags.contains(tag)) {
+        if (this.tags.contains(tag.strip())) {
             return;
         }
-        this.tags.add(tag);
+        this.tags.add(tag.strip());
     }
 
     public ArrayList<String> getTags() {
@@ -172,5 +172,17 @@ public class Email {
             Duke.getUI().showError("Hashing email name error");
         }
         return input;
+    }
+
+    public String toGuiString() {
+        String guiStr = this.subject;
+        if (tags.size() > 0) {
+            guiStr += "\n";
+            for (String tag : tags)
+            {
+                guiStr += " #" + tag;
+            }
+        }
+        return guiStr;
     }
 }

--- a/src/main/java/seedu/duke/gui/MainWindow.java
+++ b/src/main/java/seedu/duke/gui/MainWindow.java
@@ -338,7 +338,7 @@ public class MainWindow extends AnchorPane {
         //}
         ArrayList<EmailHBoxCell> list = new ArrayList<>();
         for (int i = 0; i < Duke.getEmailList().size(); i++) {
-            list.add(new EmailHBoxCell(Duke.getEmailList().get(i).getSubject(), i));
+            list.add(new EmailHBoxCell(Duke.getEmailList().get(i).toGuiString(), i));
         }
         ObservableList<EmailHBoxCell> observableList = FXCollections.observableList(list);
         emailsListView.setItems(observableList);


### PR DESCRIPTION
**Email Tag Command**
Command format: ` email update <index> -tag <tagname1> -tag <tagname2> -tag <tagname3>`
Eg:  `email update 10 -tag Internship -tag Career`

**Email text storage implementation**
`email.txt` stores tags information in the format as shown below:
aba9de65edb408fed5b66ba08e798c47487136ee9bc7a20dc4117f4db21ba817-2019-10-15-121226.htm | #CS2113T |
835b2d7f6c13a9df78cddf1880d0b74d6ff003e7632ae5725a058f1e4ed74192-2019-10-15-114326.htm | #Job #Career #Internship |

~ Will continue working on searching and listing tags, and enhancement on the gui display (not priority).

