### PR TITLE
Update command works with tags

### DIFF
--- a/src/main/java/seedu/duke/task/TaskList.java
+++ b/src/main/java/seedu/duke/task/TaskList.java
@@ -235,6 +235,25 @@ public class TaskList extends ArrayList<Task> {
     }
 
     /**
+     * Adds or modifies tags of a task.
+     *
+     * @param index Position of task in list
+     * @param tags  Priority level of task
+     * @return Confirmation message that tags have been added
+     * @throws CommandParser.UserInputException when input is in wrong format
+     */
+    public String setTags(int index, ArrayList<String> tags) throws CommandParser.UserInputException {
+        validateIndex(index);
+        Task task = this.get(index);
+        task.setTags(tags);
+        return constructSetTagsMessage(index + 1);
+    }
+
+    private String constructSetTagsMessage(int size) {
+        return "Tags of task " + size + " has been updated";
+    }
+
+    /**
      * Detect if a task being added clashes with another task in the list.
      *
      * @param task task to be added.

--- a/src/main/java/seedu/duke/task/command/TaskCommandParseHelper.java
+++ b/src/main/java/seedu/duke/task/command/TaskCommandParseHelper.java
@@ -333,7 +333,7 @@ public class TaskCommandParseHelper {
         try {
             String doAfter = extractDoAfter(optionList);
             LocalDateTime time = parseTaskTime(optionList);
-            ArrayList<String> tags = CommandParseHelper.extractTags(optionList);
+            ArrayList<String> tags = extractTags(optionList);
             String priority = extractPriority(optionList);
             return constructAddCommandByType(input, doAfter, time, tags, priority);
         } catch (CommandParseHelper.UserInputException e) {

--- a/src/main/java/seedu/duke/task/command/TaskCommandParser.java
+++ b/src/main/java/seedu/duke/task/command/TaskCommandParser.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static seedu.duke.CommandParser.extractTags;
+
 public class TaskCommandParser {
     private static UI ui = Duke.getUI();
 
@@ -233,6 +235,7 @@ public class TaskCommandParser {
             addTimeToUpdateCommand(optionList, attributes, descriptions);
             addDoAfterToUpdateCommand(optionList, attributes, descriptions);
             addPriorityToUpdateCommand(optionList, attributes, descriptions);
+            addTagsToUpdateCommand(optionList, attributes, descriptions);
             return new TaskUpdateCommand(index, descriptions, attributes);
         } catch (NumberFormatException e) {
             showError("Please enter correct task index: " + editMatcher.group(
@@ -249,7 +252,7 @@ public class TaskCommandParser {
             throws CommandParser.UserInputException {
         if (!CommandParser.extractTime(optionList).equals("")) {
             descriptions.add(CommandParser.extractTime(optionList));
-            attributes.add(TaskUpdateCommand.Attributes.time);
+            attributes.add(TaskUpdateCommand.Attributes.TIME);
         }
     }
 
@@ -259,7 +262,7 @@ public class TaskCommandParser {
             throws CommandParser.UserInputException {
         if (!extractDoAfter(optionList).equals("")) {
             descriptions.add(extractDoAfter(optionList));
-            attributes.add(TaskUpdateCommand.Attributes.doAfter);
+            attributes.add(TaskUpdateCommand.Attributes.DO_AFTER);
         }
     }
 
@@ -269,7 +272,21 @@ public class TaskCommandParser {
             throws CommandParser.UserInputException {
         if (!extractPriority(optionList).equals("")) {
             descriptions.add(extractPriority(optionList));
-            attributes.add(TaskUpdateCommand.Attributes.priority);
+            attributes.add(TaskUpdateCommand.Attributes.PRIORITY);
+        }
+    }
+
+    private static void addTagsToUpdateCommand(ArrayList<Command.Option> optionList,
+                                                   ArrayList<TaskUpdateCommand.Attributes> attributes,
+                                                   ArrayList<String> descriptions)
+            throws CommandParser.UserInputException {
+        ArrayList<String> tags = extractTags(optionList);
+        if (!tags.isEmpty()) {
+            for (String tag : tags) {
+                descriptions.add(tag);
+                attributes.add(TaskUpdateCommand.Attributes.TAG);
+            }
+
         }
     }
 
@@ -316,7 +333,7 @@ public class TaskCommandParser {
         try {
             String doAfter = extractDoAfter(optionList);
             LocalDateTime time = parseTaskTime(optionList);
-            ArrayList<String> tags = CommandParser.extractTags(optionList);
+            ArrayList<String> tags = extractTags(optionList);
             String priority = extractPriority(optionList);
             return constructAddCommandByType(input, doAfter, time, tags, priority);
         } catch (CommandParser.UserInputException e) {

--- a/src/main/java/seedu/duke/task/command/TaskUpdateCommand.java
+++ b/src/main/java/seedu/duke/task/command/TaskUpdateCommand.java
@@ -100,7 +100,7 @@ public class TaskUpdateCommand extends Command {
     private String updateTags(TaskList taskList, int i) throws CommandParseHelper.UserInputException {
         String msg;
         ArrayList<String> tags = new ArrayList<>();
-        for (int j = i; j < taskList.size(); j++) {
+        for (int j = i; j < descriptions.size(); j++) {
             if (attributes.get(j).equals(Attributes.TAG)) {
                 tags.add(descriptions.get(j));
             }

--- a/src/main/java/seedu/duke/task/command/TaskUpdateCommand.java
+++ b/src/main/java/seedu/duke/task/command/TaskUpdateCommand.java
@@ -43,14 +43,20 @@ public class TaskUpdateCommand extends Command {
         try {
             for (int i = 0; i < descriptions.size(); i++) {
                 switch (attributes.get(i)) {
-                case time:
+                case TIME:
                     msg = updateTime(taskList, i);
                     break;
-                case doAfter:
+                case DO_AFTER:
                     msg = updateDoAfter(taskList, i);
                     break;
-                case priority:
+                case PRIORITY:
                     msg = updatePriority(taskList, i);
+                    break;
+                case TAG:
+                    msg = updateTags(taskList, i);
+                    i = descriptions.size();
+                    // tags will be the last entries in descriptions ArrayList and updateTags will handle
+                    // them all. So skip to the end.
                     break;
                 default:
                     msg = "Invalid attribute";
@@ -91,7 +97,19 @@ public class TaskUpdateCommand extends Command {
         return msg;
     }
 
+    private String updateTags(TaskList taskList, int i) throws CommandParser.UserInputException {
+        String msg;
+        ArrayList<String> tags = new ArrayList<>();
+        for (int j = i; j < taskList.size(); j++) {
+            if (attributes.get(j).equals(Attributes.TAG)) {
+                tags.add(descriptions.get(j));
+            }
+        }
+        msg = taskList.setTags(index, tags);
+        return msg;
+    }
+
     public enum Attributes {
-        time, doAfter, priority
+        TIME, DO_AFTER, PRIORITY, TAG
     }
 }


### PR DESCRIPTION
The update command functionality has been extended to be able to change tags. It will overwrite any existing tags of that task (consistent with the functionality of update doafter/time/priority).

Example:
task 5 is ```[D][X] do homework by: 20/10/2019 1200 #CS2113 #graded```
```task update 5 -tag #CS2101``` will change task 5 to
```[D][X] do homework by: 20/10/2019 1200 #CS2101```