### PR TITLE
Add Coveralls for Coverage Reporting

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-pro
+repo_token: n10inJglutwxvXQG0ukfmA6MZIDMGS2Hm

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/AY1920S1-CS2113T-F11-3/main.svg?branch=master)](https://travis-ci.org/AY1920S1-CS2113T-F11-3/main)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/4d466db65d0840a6b8342b62b0882dbd)](https://www.codacy.com/manual/limryan/main?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=AY1920S1-CS2113T-F11-3/main&amp;utm_campaign=Badge_Grade)
+[![Coverage Status](https://coveralls.io/repos/github/AY1920S1-CS2113T-F11-3/main/badge.svg?branch=master)](https://coveralls.io/github/AY1920S1-CS2113T-F11-3/main?branch=master)
 # Duke Email Manager
 
 ![GUI Mockup](./docs/images/Ui.png)

--- a/docs/guides/DeveloperGuide.adoc
+++ b/docs/guides/DeveloperGuide.adoc
@@ -1,82 +1,71 @@
 = Email Manager - Developer Guide
+:site-section: DeveloperGuide
+:toc:
+:toc-title:
+:toc-placement: preamble
+:sectnums:
+:imagesDir: images
+:stylesDir: stylesheets
+:xrefstyle: full
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:warning-caption: :warning:
+endif::[]
+:repoURL: https://github.com/AY1920S1-CS2113T-F11-3/main
 
 By: F11-3
 
-. Introduction
-. https://github.com/CS2113-AY1819S2-T08-4/main/blob/master/docs/DeveloperGuide.adoc#about-the-developer-guide[About the Developer Guide]
-. Setting up
-. Design
-4.1. Architecture +
-4.2. UI component +
-4.3. Logic component +
-4.4. Model component +
-4.5. Storage component +
-4.6. Common classes
-
-. Implementation
-. Documentation
-. Testing
-. Dev Ops
-. Appendices
-Appendix A: Suggested Programming Tasks to Get Started +
-Appendix B: Product Scope +
-Appendix C: User Stories +
-Appendix D: Use Cases +
-Appendix E: Non Functional Requirements +
-Appendix F: Glossary +
-Appendix G: Product Survey +
-Appendix H: Instructions for Manual Testing
-
-
-. *Introduction*
+== Introduction
 
 Welcome to the Email Manager Developer Guide! +
 Email Manager is an email and task manager app, specifically designed for NUS School of Computing Students to manage their emails and busy schedules. As a text-based application, it is optimized for those who prefer typing and working with Command Line Interface (CLI). Email Manager also has a developed Graphical User Interface (GUI) that allows users to view email and task details in an appealing, well-organized format.
 
-. https://github.com/CS2113-AY1819S2-T08-4/main/blob/master/docs/DeveloperGuide.adoc#about-the-developer-guide[*About the Developer Guide]*
+== https://github.com/CS2113-AY1819S2-T08-4/main/blob/master/docs/DeveloperGuide.adoc#about-the-developer-guide[*About the Developer Guide]*
 
 This developer guide provides detailed documentation on the implementation of all the various features Email Manager offers. It also suggests methods for you to modify and build upon it. +
 Throughout this developer guide, there will be various icons used, as shown below:
-|===
-|💡|This is a tip. Follow these tips to aid your development of Email Manager.
 
-|===
+[TIP]
+This is a tip. Follow these tips to aid your development of Email Manager.
 
-|===
-|ℹ️|This is a note. Read these for additional information.
+[NOTE]
+This is a note. Read these for additional information.
 
-|===
+[WARNING]
+This is a warning. Heed these warnings to avoid making mistakes that will hamper your development efforts.
 
-|===
-|⚠️|This is a warning. Heed these warnings to avoid making mistakes that will hamper your development efforts.
-
-|===
-
-. *Setting up*
+== Setting up
 
 This section shows how to set up Email Manager on your desktop and begin your development journey.
 
-. *Design*
-4.1. Architecture
+== Design
+=== Architecture
 
 Figure 1. Architecture Diagram +
-The _Architecture Diagram_ given above explains the high-level design of the App. Given below is a quick overview of each component. +
-4.2. UI component +
-4.3. Logic component +
-4.4. Model component +
-4.5. Storage component +
-4.6. Common classes
+The _Architecture Diagram_ given above explains the high-level design of the App. Given below is a quick overview of each component.
 
-. *Implementation*
+=== UI component
 
-. *Documentation*
+=== Logic component
 
-. *Testing*
+=== Model component
 
-. *Dev Ops*
+=== Storage component
 
+=== Common classes
 
-*Appendix B: Product Scope*
+==== Implementation
+
+==== Documentation
+
+==== Testing
+
+==== Dev Ops
+
+== Appendices
+
+=== Appendix B: Product Scope
 
 Target user profile:
 
@@ -92,7 +81,7 @@ Value proposition:
 . Helps busy computing student to manage their tasks and schedules.
 . Reminds busy computing students of their important emails and tasks.
 
-*Appendix C: User Stories*
+=== Appendix C: User Stories
 
 |===
 |*As a/an*|*I can*|*So that...*|*Priority*
@@ -134,7 +123,7 @@ Value proposition:
 
 
 
-*Appendix D: Use Cases*
+=== Appendix D: Use Cases
 
 System: Email Manager +
 Actor: User (SoC student)
@@ -180,7 +169,7 @@ Use case ends.
 . The app will look through the emails and put the related-emails under the category.
 
 
-*Appendix E: Non-Functional Requirements*
+=== Appendix E: Non-Functional Requirements
 
 Email Manager meets the following non-functional requirements:
 
@@ -191,10 +180,10 @@ Email Manager meets the following non-functional requirements:
 * Works with common operating systems
 
 
-*Appendix F: Glossary*
+=== Appendix F: Glossary
 
-*Appendix G: Product Survey*
+=== Appendix G: Product Survey
 
-*Appendix H: Instructions for Manual Testing*
+=== Appendix H: Instructions for Manual Testing
 
 

--- a/docs/guides/UserGuide.adoc
+++ b/docs/guides/UserGuide.adoc
@@ -1,53 +1,23 @@
 = Email Manager - User Guide
+:site-section: DeveloperGuide
+:toc:
+:toc-title:
+:toc-placement: preamble
+:sectnums:
+:imagesDir: images
+:stylesDir: stylesheets
+:xrefstyle: full
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:warning-caption: :warning:
+endif::[]
 
-By: F11-3	Since: Oct 2019
-
-. Introduction
-. About User Guide
-. Quick Start
-2.1	Installation +
-2.2	Introducing the interface +
-2.3	Try it out!
-
-. Features
-.. General Commands
-... Viewing help: help
-... Exiting the program: exit
-... Apply colour code: colour
-... View Schedule: schedule
-.. Task Manager
-... List Tasks Commands: list
-... Add Tasks Commands
-.... Adding a todo: todo
-.... Adding an deadline: deadline
-.... Adding an event: event
-... Edit Tasks Commands: edit
-... Delete Tasks Commands: delete
-... Find task(s) with keyword: find
-... Done a task: done
-... Reminder for upcoming task(s): reminder
-... Do after: doafter
-... Snooze a task: snooze
-... Detect Anomalies
-... Tagging Task: tag
-.. Email Manager
-... Listing all emails: email -list
-... Showing an email : email -show
-... Fetching emails from server: email -fetch
-... Filtering Email: email -filter
-... Tagging Email: email -tag
-.. Linking Tasks and Email
-.. Apply priority level
-.. Saving data
-.. Sending Email (coming in v2.0)
-.. Auto delete emails (coming in v2.0)
+By: F11-3 +
+Since: Oct 2019
 
 
-
-. FAQ
-. Command Summary
-
-. Introduction
+== Introduction
 
 
 Figure 1. GUI Interface
@@ -56,54 +26,50 @@ Email Manager is an email and task manager app, specifically designed for NUS Sc
 
 If you are a busy computing student who is tired of receiving too many emails, you may find this app useful. Jump to [Quick Start] to get started and enjoy!
 
-. About User Guide
+== About User Guide
 This user guide shows you how to get started with Email Manager. It introduces you to the features of Email Manager and provides you with examples, that you will become an expert user very soon! +
 Throughout this user guide, there will be various icons used, as shown below:
-|===
-|💡|This is a tip. Following these suggestions will make using Email Manager much simpler!
+[TIP]
+This is a tip. Following these suggestions will make using Email Manager much simpler!
+[NOTE]
+This is a note. Read these for additional information.
+[WARNING]
+This is a warning. Heed the warnings for Email Manager to work smoothly!
 
-|===
 
-|===
-|ℹ️|This is a note. Read these for additional information.
+== Quick Start
 
-|===
+This section serves as a tutorial for a new user to Email Manager.
 
-|===
-|⚠️|This is a warning. Heed the warnings for Email Manager to work smoothly!
-
-|===
-
-. Quick Start
-
-This section serves as a tutorial for a new user to Email Manager. +
-3.1 Installation
+=== Installation
 
 . Ensure you have Java version 9 or later installed in your computer.
 . Download the latest email_manager.jar here.
 . Copy the file to the folder you want to use as the home folder for Email Manager.
 . Double-click the file to start the app. The GUI window should appear in a few seconds and will look like this:
-3.2 Introducing the Interface
 
-3.3 Try It Out! +
+=== Introducing the Interface
+
+=== Try It Out!
 Now that you understand the app’s interface, you can now try keying in commands to interact with Email Manager. +
 Type the command in the command box and press Enter to execute it. +
 e.g. typing help and pressing Enter opens the help window. +
 Some example commands you can try in task mode:
 
-* list: lists all tasks
-* deadline submit report -time 12/12/2019 2359: adds a deadline task named submit report to your task list
-* event meeting -time 10/09/2019 1200 -tag work:  adds an event task named meeting to your task list.
+* `list`: lists all tasks
+* `deadline submit report -time 12/12/2019 2359`: adds a deadline task named submit report to your task list
+* `event meeting -time 10/09/2019 1200 -tag work`:  adds an event task named meeting to your task list.
+
 Some example commands you can try in email mode:
 
-* list: lists all the emails
-* show 3: shows the 3rd email shown in the email list
+* `list`: lists all the emails
+* `show 3`: shows the 3rd email shown in the email list
 An example command you can try in both modes:
 
-* bye : exits the app
+* `bye` : exits the app
 Refer to Features for details of each command.
 
-. Features
+== Features
 
 This section tells you about the features available in Email Manager and how to use them.
 
@@ -116,124 +82,121 @@ e.g. if the command states -time TIME, TIME is a parameter which can be used as 
 * Items in square brackets are optional.
 e.g. -time TIME [-tag TAG] can be used as -time 12/12/2019 1200 -tag urgent or as -time 12/12/2019 1200.
 
-Note: You are only allowed to enter alphanumeric (a-z, A-Z, 0-9), space and underscore (_) characters. All other symbols will not be accepted by Email Manager.
+[NOTE]
+You are only allowed to enter alphanumeric (a-z, A-Z, 0-9), space and underscore (_) characters. All other symbols will not be accepted by Email Manager.
 
 
-.. General Commands
-|===
-|ℹ️|General commands will work in either mode.
+=== General Commands
 
-|===
+[INFO]
+General commands will work in either mode.
 
-
-... Viewing help: help
-Format: help +
+==== Viewing help: `help`
+Format: `help` +
 A pop up window appears and gives information on what commands are available and its respective format.
 
-... Exiting the program: bye
-Format: bye +
+==== Exiting the program: `bye`
+Format: `bye` +
 Exits the program and closes the window.
 
+[WARNING]
+If the program is closed without using the bye command, the program will exit without saving the data.
 
-|===
-|⚠️|If the program is closed without using the bye command, the program will exit without saving the data.
+==== Apply colour code: `colour` (coming in v2.0)
+Format: `colour ITEM_NUMBER COLOUR` +
+The specified item will be shown in the colour from the command.
 
-|===
+=== Task Mode
 
-
-
-... Apply colour code: colour (coming in v2.0)
-			Format: colour ITEM_NUMBER -c COLOUR +
-		The specified item will be shown in the colour from the command.
-
-.. Task Manager (Mode)
-
-... List Tasks Commands: list
-Format: list +
-Gives a complete list of tasks.
-
-... Add Tasks Commands
-.... Adding a todo: todo
-Format: todo TASK_NAME [-doafter DOAFTER_TASK][-priority PRIORITY_LEVEL][-tag TAG1]... +
+==== Add Tasks Commands
+===== Adding a todo: `todo`
+Format: `todo TASK_NAME [-doafter DOAFTER_TASK][-priority PRIORITY_LEVEL][-tag TAG1]...` +
 Adds a task of todo type.
 
-.... Adding an deadline: deadline
-Format: deadline TASK_NAME -time dd/mm/yyyy hhMM [-doafter DOAFTER_TASK][-priority PRIORITY_LEVEL][-tag TAG1]... +
+===== Adding an deadline: `deadline`
+Format: `deadline TASK_NAME -time dd/mm/yyyy hhMM [-doafter DOAFTER_TASK][-priority PRIORITY_LEVEL][-tag TAG1]...` +
 Adds a task that has a deadline. The task name and deadline are required. A doafter task, priority level or any number of tags are all optional. Order of the modifiers does not matter.
 
-.... Adding an event: event
-Format: event TASK_NAME -time dd/mm/yyyy hhMM [-doafter DOAFTER_TASK][-priority PRIORITY_LEVEL][-tag TAG1]... +
+===== Adding an event: `event`
+Format: `event TASK_NAME -time dd/mm/yyyy hhMM [-doafter DOAFTER_TASK][-priority PRIORITY_LEVEL][-tag TAG1]...` +
 Adds a task of event type.
 
-... Update Tasks Commands: update
+==== List Tasks Commands: `list`
+Format: `list` +
+Gives a complete list of tasks.
 
+==== Update Tasks Commands: `update`
 
-... Delete Tasks Commands: delete
-Format: delete ITEM_NUMBER +
+==== Delete Tasks Commands: `delete`
+Format: `delete ITEM_NUMBER` +
 Deletes the item specified.
 
-... Find task(s) with keyword: find
-Format: find KEYWORD +
+==== Find task(s) with keyword: `find`
+Format: `find KEYWORD` +
 Returns a list of items that contains KEYWORD. This feature will search all the attributes of a task. Example: find cat will return cat, tabby #cat, SoCcat, concatenation.
 
-... Done a task: done
-Format: done ITEM_NUMBER +
+==== Done a task: `done`
+Format: `done ITEM_NUMBER` +
 Marks the item specified as done.
 
-... Reminder for upcoming task(s): reminder
-Format: reminder [-time dd/MM/yyyy HHmm] +
+==== Reminder for upcoming task(s): `reminder`
+Format: `reminder [-time dd/MM/yyyy HHmm]` +
 By default, it will show tasks due in the next 3 days. If a time modifier is added, it will show all tasks from current date to date specified. Example: if the current date is 14/03/2020, reminder will show hand in homework by: 15/03/2020 2359, presentation at 17/03/2020 1400. reminder 21/03/2020 will show hand in homework by: 15/03/2020 2359, presentation at: 17/03/2020 1400, exam at: 20/03/2020 0900, and flight at: 21/03/2020 1745.
 
 
-... Do after: doafter
-Format: doafter ITEM_NUMBER  +
-Marks the item specified as done. Only one doafter task can be added. To modify an existing doafter task, see the update command.
+==== Do after: `doafter`
+Format: `doafter ITEM_NUMBER`  +
+Marks the item specified as done.
 
-... Snooze a task: snooze
+[NOTE]
+Only one doafter task can be added. To modify an existing doafter task, see the update command.
 
-... Detect Anomalies
+==== Snooze a task: `snooze`
 
-... Tagging a task: tag
-Format: tag ITEM_NUMBER -tag TAG1 [-tag TAG2]... +
+==== Detect Anomalies
+
+==== Tagging a task: `tag`
+Format: `tag ITEM_NUMBER -tag TAG1 [-tag TAG2]...` +
 Tags the specified item with the tag(s) minimum number of tags is 1.
 
-.. Email Manager (Mode)
+=== Email Mode
 
-... Listing all emails: list
-Format: list +
+==== Listing all emails: `list`
+Format: `list` +
 Gives a complete list of emails.
 
-... Showing an email : show
-			Format: show INDEX_NUMBER +
+==== Showing an email: `show`
+Format: `show INDEX_NUMBER` +
 Show the email at the index number in the email list.
 
-... Fetching emails from server: fetch
-Format: fetch +
+==== Fetching emails from server: `fetch`
+Format: `fetch` +
 Fetches email from Outlook.com.
 
-... Filtering Email: list
-Format: list [-tag TAG1] [-tag TAG2]... +
+==== Filtering email: 'list`
+Format: `list [-tag TAG1] [-tag TAG2]...` +
 Gives a list of emails with the tags. Minimum number of tags is 1, and the maximum is 2.
 
-... Tagging Email: update
-Format:  update ITEM_NUMBER [-tag TAG1] [-tag TAG2]... +
+==== Tagging Email: `update`
+Format: `update ITEM_NUMBER [-tag TAG1] [-tag TAG2]...` +
 Tags the specified item with the tag(s) minimum number of tags is 1.
 
-... Sending Email (coming in v2.0)
+==== Sending Email (coming in v2.0)
 
-... Auto delete emails (coming in v2.0)
-.. Linking Tasks and Email
+==== Auto delete emails (coming in v2.0)
 
-.. Apply priority level
+==== Linking Tasks and Email
 
-.. Saving data
+==== Apply priority level
+
+=== Saving data
 Data is automatically saved after any command modifies the file. +
 (Question: should it be only saved when user exits the program by the “bye” command?)
 
-. FAQ
+== FAQ
 Placeholder text for FAQ.
 
-. Command Summary (Quick Guide)
+== Command Summary (Quick Guide)
 * List
 * Filter
 * Tags


### PR DESCRIPTION
We use [Coveralls](https://coveralls.io/) to track the code coverage of our projects. See [UsingCoveralls.adoc](https://github.com/nusCS2113-AY1920S1/addressbook-level3/blob/master/docs/UsingCoveralls.adoc) for more details.