### PR TITLE
Refactored TaskLinkCommand 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Duke will help you to sort, filter and clear you inbox.
 
 **Features**
 
-* Add dates of action items
-* Mark emails with different levels of priority
-* Colour code emails
-* Tag and filter emails
+* Fetch emails from email provider
+* Filter, highlight and tag emails
+* Add and manage tasks related to these emails
+* Easy to use interface
 
 **Getting started**
 

--- a/src/main/java/seedu/duke/email/EmailList.java
+++ b/src/main/java/seedu/duke/email/EmailList.java
@@ -96,12 +96,12 @@ public class EmailList extends ArrayList<Email> {
     /**
      * Finds the email with the input SHA hash and converts into subject.
      *
-     * @param Sha the identifier to be converted
+     * @param sha the identifier to be converted
      * @return    Subject that corresponds to the SHA hash
      */
-    public String convertShaToSubject(String Sha) {
+    public String convertShaToSubject(String sha) {
         for (Email email : this) {
-            if (Sha.equals(email.getShaHash())) {
+            if (sha.equals(email.getShaHash())) {
                 return email.getSubject();
             }
         }
@@ -111,13 +111,13 @@ public class EmailList extends ArrayList<Email> {
     /**
      * Finds the email with the input SHA hash and converts into index.
      *
-     * @param Sha the identifier to be converted
+     * @param sha the identifier to be converted
      * @return    Index that corresponds to the SHA hash
      */
-    public int convertShaToIndex(String Sha) {
-        for (int i = 0 ; i < this.size(); i++) {
+    public int convertShaToIndex(String sha) {
+        for (int i = 0; i < this.size(); i++) {
             Email email = this.get(i);
-            if (Sha.equals(email.getShaHash())) {
+            if (sha.equals(email.getShaHash())) {
                 return i;
             }
         }

--- a/src/main/java/seedu/duke/email/EmailList.java
+++ b/src/main/java/seedu/duke/email/EmailList.java
@@ -6,9 +6,7 @@ import seedu.duke.email.entity.Email;
 import seedu.duke.email.parser.EmailContentParseHelper;
 
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 
 public class EmailList extends ArrayList<Email> {
@@ -83,7 +81,7 @@ public class EmailList extends ArrayList<Email> {
 
 
     /**
-     * Delete email at the given index from eh email list.
+     * Delete email at the given index from the email list.
      *
      * @param index of email to be deleted
      * @return confirmation message to be displayed to user
@@ -93,6 +91,37 @@ public class EmailList extends ArrayList<Email> {
         this.remove(email);
         String responseMsg = constructDeleteMessage(email);
         return responseMsg;
+    }
+
+    /**
+     * Finds the email with the input SHA hash and converts into subject.
+     *
+     * @param Sha the identifier to be converted
+     * @return    Subject that corresponds to the SHA hash
+     */
+    public String convertShaToSubject(String Sha) {
+        for (Email email : this) {
+            if (Sha.equals(email.getShaHash())) {
+                return email.getSubject();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the email with the input SHA hash and converts into index.
+     *
+     * @param Sha the identifier to be converted
+     * @return    Index that corresponds to the SHA hash
+     */
+    public int convertShaToIndex(String Sha) {
+        for (int i = 0 ; i < this.size(); i++) {
+            Email email = this.get(i);
+            if (Sha.equals(email.getShaHash())) {
+                return i;
+            }
+        }
+        return 0;
     }
 
     private String constructDeleteMessage(Email email) {

--- a/src/main/java/seedu/duke/task/command/TaskLinkCommand.java
+++ b/src/main/java/seedu/duke/task/command/TaskLinkCommand.java
@@ -1,5 +1,6 @@
-package seedu.duke.common.command;
+package seedu.duke.task.command;
 
+import seedu.duke.common.command.Command;
 import seedu.duke.common.model.Model;
 import seedu.duke.email.EmailList;
 import seedu.duke.email.entity.Email;
@@ -9,7 +10,7 @@ import seedu.duke.ui.UI;
 
 import java.util.ArrayList;
 
-public class LinkCommand extends Command {
+public class TaskLinkCommand extends Command {
     private ArrayList<Integer> taskIndexList;
     private ArrayList<Integer> emailIndexList;
 
@@ -19,7 +20,7 @@ public class LinkCommand extends Command {
      * @param taskIndexList  the index of tasks that is to be linked together.
      * @param emailIndexList the index of emails that is to be linked.
      */
-    public LinkCommand(ArrayList<Integer> taskIndexList, ArrayList<Integer> emailIndexList) {
+    public TaskLinkCommand(ArrayList<Integer> taskIndexList, ArrayList<Integer> emailIndexList) {
         this.taskIndexList = taskIndexList;
         this.emailIndexList = emailIndexList;
     }

--- a/src/main/java/seedu/duke/task/command/TaskLinkCommand.java
+++ b/src/main/java/seedu/duke/task/command/TaskLinkCommand.java
@@ -63,7 +63,8 @@ public class TaskLinkCommand extends Command {
         msg.append(" with email(s): ");
         Task task = taskList.get(taskIndex);
 
-        for (Integer index : emailIndexList) {
+        for (int i = emailIndexList.size()-1; i >= 0; i--) {
+            int index = emailIndexList.get(i);
             msg.append((index+1) + " ");
             Email email = emailList.get(index);
             if (linkedEmails.contains(email.getShaHash())) {
@@ -78,27 +79,24 @@ public class TaskLinkCommand extends Command {
         if (linkedEmails.isEmpty()) {
             msg.append("No linked emails currently.");
         } else {
-            //TODO make function in EmailList to return Array List of email subjects (and maybe index)
-            //TODO create function to convert SHA to Subject
             msg.append("Here are your linked emails:" + System.lineSeparator());
-            int i = 1;
+            int listIndex = 1;
             for (String filename : linkedEmails) {
-                String name = null;
-                for (int j = 0; j < emailList.size(); j++) {
-                    if (filename.equals(emailList.get(j).getShaHash())) {
-                        name = emailList.get(j).getSubject();
-                        break;
-                    }
+                if (emailList.convertShaToSubject(filename) == null) {
+                    linkedEmails.remove(filename);
+                } else {
+                    String name = emailList.convertShaToSubject(filename);
+                    msg.append(listIndex + ". " + name + System.lineSeparator());
+                    listIndex++;
                 }
-                msg.append(i + ". " + name + System.lineSeparator());
-                i++;
             }
 
+            int firstIndex = emailList.convertShaToIndex(linkedEmails.get(0));
+            String[] parsedMsg = emailList.show(firstIndex);
+            UI.getInstance().setEmailContent(parsedMsg[1]);
+            UI.getInstance().updateHtml();
+            responseMsg = msg.toString();
         }
-        String[] parsedMsg = emailList.show(1);
-        UI.getInstance().setEmailContent(parsedMsg[1]);
-        UI.getInstance().updateHtml();
-        responseMsg = msg.toString();
     }
 
     private void deleteLinks(StringBuilder msg, ArrayList<String> linkedEmails) {

--- a/src/main/java/seedu/duke/task/command/TaskLinkCommand.java
+++ b/src/main/java/seedu/duke/task/command/TaskLinkCommand.java
@@ -45,50 +45,60 @@ public class TaskLinkCommand extends Command {
             deleteLinks(msg, linkedEmails);
         }
 
-        if (emailIndexList.isEmpty()) {
-            if (linkedEmails.isEmpty()) {
-                msg.append("No linked emails currently.");
-            } else {
-                //TODO make function in EmailList to return Array List of email subjects (and maybe index)
-                //TODO create function to convert SHA to Subject
-                msg.append("Here are your linked emails:" + System.lineSeparator());
-                int i = 1;
-                for (String filename : linkedEmails) {
-                    String name = null;
-                    for (int j = 0; j < emailList.size(); j++) {
-                        if (filename.equals(emailList.get(j).getShaHash())) {
-                            name = emailList.get(j).getSubject();
-                            break;
-                        }
-                    }
-                    msg.append(i + ". " + name + System.lineSeparator());
-                    i++;
-                }
-            }
+        if (!emailIndexList.isEmpty()) {
+            addLinks(taskList, emailList, msg, linkedEmails);
+        }
+
+        listLinkedEmails(emailList, msg, linkedEmails);
+
+        if (!silent) {
             responseMsg = msg.toString();
             UI.getInstance().showResponse(msg.toString());
-            return true;
-        } else {
-            msg.append("Linked task ");
-            Task task = taskList.get(taskIndex);
-            msg.append(task.getName());
-            msg.append(" with email(s):" + System.lineSeparator());
-
-            for (int j = 0; j < emailIndexList.size(); j++) {
-                Email email = emailList.get(emailIndexList.get(j));
-                msg.append(email.getSubject() + System.lineSeparator());
-                if (task.getLinkedEmails().contains(email.getShaHash())) {
-                    continue;
-                }
-                task.addLinkedEmails(email.getShaHash());
-            }
-
-            if (!silent) {
-                responseMsg = msg.toString();
-                UI.getInstance().showResponse(msg.toString());
-            }
-            return true;
         }
+        return true;
+    }
+
+    private void addLinks(TaskList taskList, EmailList emailList, StringBuilder msg, ArrayList<String> linkedEmails) {
+        msg.append("Linked task " + (taskIndex+1));
+        msg.append(" with email(s): ");
+        Task task = taskList.get(taskIndex);
+
+        for (Integer index : emailIndexList) {
+            msg.append((index+1) + " ");
+            Email email = emailList.get(index);
+            if (linkedEmails.contains(email.getShaHash())) {
+                continue;
+            }
+            task.addLinkedEmails(email.getShaHash());
+        }
+        msg.append(System.lineSeparator());
+    }
+
+    private void listLinkedEmails(EmailList emailList, StringBuilder msg, ArrayList<String> linkedEmails) {
+        if (linkedEmails.isEmpty()) {
+            msg.append("No linked emails currently.");
+        } else {
+            //TODO make function in EmailList to return Array List of email subjects (and maybe index)
+            //TODO create function to convert SHA to Subject
+            msg.append("Here are your linked emails:" + System.lineSeparator());
+            int i = 1;
+            for (String filename : linkedEmails) {
+                String name = null;
+                for (int j = 0; j < emailList.size(); j++) {
+                    if (filename.equals(emailList.get(j).getShaHash())) {
+                        name = emailList.get(j).getSubject();
+                        break;
+                    }
+                }
+                msg.append(i + ". " + name + System.lineSeparator());
+                i++;
+            }
+
+        }
+        String[] parsedMsg = emailList.show(1);
+        UI.getInstance().setEmailContent(parsedMsg[1]);
+        UI.getInstance().updateHtml();
+        responseMsg = msg.toString();
     }
 
     private void deleteLinks(StringBuilder msg, ArrayList<String> linkedEmails) {

--- a/src/main/java/seedu/duke/task/command/TaskLinkCommand.java
+++ b/src/main/java/seedu/duke/task/command/TaskLinkCommand.java
@@ -59,13 +59,13 @@ public class TaskLinkCommand extends Command {
     }
 
     private void addLinks(TaskList taskList, EmailList emailList, StringBuilder msg, ArrayList<String> linkedEmails) {
-        msg.append("Linked task " + (taskIndex+1));
+        msg.append("Linked task " + (taskIndex + 1));
         msg.append(" with email(s): ");
         Task task = taskList.get(taskIndex);
 
-        for (int i = emailIndexList.size()-1; i >= 0; i--) {
+        for (int i = emailIndexList.size() - 1; i >= 0; i--) {
             int index = emailIndexList.get(i);
-            msg.append((index+1) + " ");
+            msg.append((index + 1) + " ");
             Email email = emailList.get(index);
             if (linkedEmails.contains(email.getShaHash())) {
                 continue;
@@ -104,7 +104,7 @@ public class TaskLinkCommand extends Command {
             if (deleteIndex < linkedEmails.size() && deleteIndex >= 0) {
                 linkedEmails.remove(deleteIndex);
             } else {
-                msg.append("Link " + (deleteIndex+1) + " does not exist. ");
+                msg.append("Link " + (deleteIndex + 1) + " does not exist. ");
             }
         }
         msg.append("Valid links have been deleted. ");

--- a/src/main/java/seedu/duke/task/command/TaskLinkCommand.java
+++ b/src/main/java/seedu/duke/task/command/TaskLinkCommand.java
@@ -11,18 +11,21 @@ import seedu.duke.ui.UI;
 import java.util.ArrayList;
 
 public class TaskLinkCommand extends Command {
-    private ArrayList<Integer> taskIndexList;
+    private int taskIndex;
     private ArrayList<Integer> emailIndexList;
+    private ArrayList<Integer> deleteIndexList;
 
     /**
      * Instantiates link command with all the necessary variables.
      *
-     * @param taskIndexList  the index of tasks that is to be linked together.
-     * @param emailIndexList the index of emails that is to be linked.
+     * @param taskIndex       the index of task that is to be linked together.
+     * @param emailIndexList  the index of emails that is to be linked.
+     * @param deleteIndexList the index of link to be deleted for the specified task.
      */
-    public TaskLinkCommand(ArrayList<Integer> taskIndexList, ArrayList<Integer> emailIndexList) {
-        this.taskIndexList = taskIndexList;
+    public TaskLinkCommand(int taskIndex, ArrayList<Integer> emailIndexList, ArrayList<Integer> deleteIndexList) {
+        this.taskIndex = taskIndex;
         this.emailIndexList = emailIndexList;
+        this.deleteIndexList = deleteIndexList;
     }
 
     /**
@@ -36,9 +39,13 @@ public class TaskLinkCommand extends Command {
         TaskList taskList = model.getTaskList();
         EmailList emailList = model.getEmailList();
         StringBuilder msg = new StringBuilder();
+        ArrayList<String> linkedEmails = taskList.get(taskIndex).getLinkedEmails();
+
+        if (!deleteIndexList.isEmpty()) {
+            deleteLinks(msg, linkedEmails);
+        }
 
         if (emailIndexList.isEmpty()) {
-            ArrayList<String> linkedEmails = taskList.get(taskIndexList.get(0)).getLinkedEmails();
             if (linkedEmails.isEmpty()) {
                 msg.append("No linked emails currently.");
             } else {
@@ -63,25 +70,36 @@ public class TaskLinkCommand extends Command {
             return true;
         } else {
             msg.append("Linked task ");
-            for (int i = 0; i < taskIndexList.size(); i++) {
-                Task task = taskList.get(taskIndexList.get(i));
-                msg.append(task.getName());
-                msg.append(" with email(s):" + System.lineSeparator());
+            Task task = taskList.get(taskIndex);
+            msg.append(task.getName());
+            msg.append(" with email(s):" + System.lineSeparator());
 
-                for (int j = 0; j < emailIndexList.size(); j++) {
-                    Email email = emailList.get(emailIndexList.get(j));
-                    msg.append(email.getSubject() + System.lineSeparator());
-                    if (task.getLinkedEmails().contains(email.getShaHash())) {
-                        continue;
-                    }
-                    task.addLinkedEmails(email.getShaHash());
+            for (int j = 0; j < emailIndexList.size(); j++) {
+                Email email = emailList.get(emailIndexList.get(j));
+                msg.append(email.getSubject() + System.lineSeparator());
+                if (task.getLinkedEmails().contains(email.getShaHash())) {
+                    continue;
                 }
+                task.addLinkedEmails(email.getShaHash());
             }
+
             if (!silent) {
                 responseMsg = msg.toString();
                 UI.getInstance().showResponse(msg.toString());
             }
             return true;
         }
+    }
+
+    private void deleteLinks(StringBuilder msg, ArrayList<String> linkedEmails) {
+        for (int deleteIndex : deleteIndexList) {
+            if (deleteIndex < linkedEmails.size() && deleteIndex >= 0) {
+                linkedEmails.remove(deleteIndex);
+            } else {
+                msg.append("Link " + (deleteIndex+1) + " does not exist. ");
+            }
+        }
+        msg.append("Valid links have been deleted. ");
+        msg.append(System.lineSeparator() + System.lineSeparator());
     }
 }

--- a/src/main/java/seedu/duke/task/command/TaskUpdateCommand.java
+++ b/src/main/java/seedu/duke/task/command/TaskUpdateCommand.java
@@ -39,28 +39,32 @@ public class TaskUpdateCommand extends Command {
     @Override
     public boolean execute(Model model) {
         TaskList taskList = model.getTaskList();
-        String msg = "";
+        StringBuilder msg = new StringBuilder("Updating is complete");
+        msg.append(System.lineSeparator());
         responseMsg = "";
         try {
             for (int i = 0; i < descriptions.size(); i++) {
                 switch (attributes.get(i)) {
                 case TIME:
-                    msg = updateTime(taskList, i);
+                    msg.append(updateTime(taskList, i));
+                    msg.append(System.lineSeparator());
                     break;
                 case DO_AFTER:
-                    msg = updateDoAfter(taskList, i);
+                    msg.append(updateDoAfter(taskList, i));
+                    msg.append(System.lineSeparator());
                     break;
                 case PRIORITY:
-                    msg = updatePriority(taskList, i);
+                    msg.append(updatePriority(taskList, i));
+                    msg.append(System.lineSeparator());
                     break;
                 case TAG:
-                    msg = updateTags(taskList, i);
+                    msg.append(updateTags(taskList, i));
                     i = descriptions.size();
                     // tags will be the last entries in descriptions ArrayList and updateTags will handle
                     // them all. So skip to the end.
                     break;
                 default:
-                    msg = "Invalid attribute";
+                    msg = new StringBuilder("Invalid attribute");
                     break;
                 }
             }
@@ -72,7 +76,7 @@ public class TaskUpdateCommand extends Command {
             return false;
         }
         if (!silent) {
-            UI.getInstance().showResponse(msg);
+            UI.getInstance().showResponse(msg.toString());
         }
         return true;
     }

--- a/src/main/java/seedu/duke/task/parser/TaskCommandParseHelper.java
+++ b/src/main/java/seedu/duke/task/parser/TaskCommandParseHelper.java
@@ -3,7 +3,7 @@ package seedu.duke.task.parser;
 import javafx.util.Pair;
 import seedu.duke.common.parser.CommandParseHelper;
 import seedu.duke.common.command.InvalidCommand;
-import seedu.duke.common.command.LinkCommand;
+import seedu.duke.task.command.TaskLinkCommand;
 import seedu.duke.common.command.HelpCommand;
 import seedu.duke.common.command.Command;
 import seedu.duke.common.command.FlipCommand;
@@ -525,7 +525,7 @@ public class TaskCommandParseHelper {
             ArrayList<Integer> emailIndexList = extractEmails(optionList);
             ArrayList<Integer> taskIndexList = new ArrayList<>();
             taskIndexList.add(index);
-            return new LinkCommand(taskIndexList, emailIndexList);
+            return new TaskLinkCommand(taskIndexList, emailIndexList);
         } catch (TaskParseException e) {
             return new InvalidCommand("Please enter a valid task index");
         } catch (EmailParseException e) {

--- a/src/main/java/seedu/duke/task/parser/TaskCommandParseHelper.java
+++ b/src/main/java/seedu/duke/task/parser/TaskCommandParseHelper.java
@@ -292,8 +292,10 @@ public class TaskCommandParseHelper {
         } catch (NumberFormatException e) {
             return new InvalidCommand("Please enter a valid task index (positive integer equal or less "
                     + "than the number of tasks)");
+        } catch (TaskParseException e) {
+            return new InvalidCommand(e.getMessage());
         } catch (CommandParseHelper.CommandParseException e) {
-            return new InvalidCommand("Index out of bound");
+            return new InvalidCommand("Index out of bounds");
         }
     }
 
@@ -312,7 +314,9 @@ public class TaskCommandParseHelper {
                                                   ArrayList<String> descriptions)
             throws TaskParseException {
         if (!extractDoAfter(optionList).equals("")) {
-            descriptions.add(extractDoAfter(optionList));
+            String doafter = extractDoAfter(optionList);
+            System.out.println(doafter);
+            descriptions.add(doafter);
             attributes.add(TaskUpdateCommand.Attributes.DO_AFTER);
         }
     }

--- a/src/main/java/seedu/duke/task/parser/TaskCommandParseHelper.java
+++ b/src/main/java/seedu/duke/task/parser/TaskCommandParseHelper.java
@@ -521,11 +521,10 @@ public class TaskCommandParseHelper {
                     + "the number of tasks) and email indexes (optional)");
         }
         try {
-            int index = parseTaskIndex(linkCommandMatcher.group("index"));
+            int taskIndex = parseTaskIndex(linkCommandMatcher.group("index"));
             ArrayList<Integer> emailIndexList = extractEmails(optionList);
-            ArrayList<Integer> taskIndexList = new ArrayList<>();
-            taskIndexList.add(index);
-            return new TaskLinkCommand(taskIndexList, emailIndexList);
+            ArrayList<Integer> deleteIndexList = extractDelete(optionList);
+            return new TaskLinkCommand(taskIndex, emailIndexList, deleteIndexList);
         } catch (TaskParseException e) {
             return new InvalidCommand("Please enter a valid task index");
         } catch (EmailParseException e) {
@@ -552,6 +551,23 @@ public class TaskCommandParseHelper {
             }
         }
         return emailList;
+    }
+
+    /**
+     * Extracts email index from the option list.
+     *
+     * @param optionList the list of options where the parameters are extracted
+     * @return the ArrayList of email index
+     */
+    public static ArrayList<Integer> extractDelete(ArrayList<Command.Option> optionList) {
+        ArrayList<Integer> deleteList = new ArrayList<>();
+        for (Command.Option option : optionList) {
+            if (option.getKey().equals("delete")) {
+                int index = Integer.parseInt(option.getValue().strip()) - 1;
+                deleteList.add(index);
+            }
+        }
+        return deleteList;
     }
 
     /**

--- a/src/test/java/seedu/duke/CommandParseHelperTest.java
+++ b/src/test/java/seedu/duke/CommandParseHelperTest.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CommandParserHelperTest {
+public class CommandParseHelperTest {
     @Test
     public void parseEmailCommandTest() {
         Email emailOne = new Email("TestEmailOne");

--- a/src/test/java/seedu/duke/TaskCommandParseHelperTest.java
+++ b/src/test/java/seedu/duke/TaskCommandParseHelperTest.java
@@ -5,14 +5,7 @@ import seedu.duke.common.command.Command;
 import seedu.duke.common.command.InvalidCommand;
 import seedu.duke.common.parser.CommandParseHelper;
 import seedu.duke.task.TaskList;
-import seedu.duke.task.command.TaskAddCommand;
-import seedu.duke.task.command.TaskDeleteCommand;
-import seedu.duke.task.command.TaskDoAfterCommand;
-import seedu.duke.task.command.TaskDoneCommand;
-import seedu.duke.task.command.TaskFindCommand;
-import seedu.duke.task.command.TaskReminderCommand;
-import seedu.duke.task.command.TaskSnoozeCommand;
-import seedu.duke.task.command.TaskUpdateCommand;
+import seedu.duke.task.command.*;
 import seedu.duke.task.entity.Task;
 import seedu.duke.task.parser.TaskCommandParseHelper;
 
@@ -458,6 +451,48 @@ public class TaskCommandParseHelperTest {
             ArrayList<Command.Option> optionListEmpty = new ArrayList<>();
             //no description
             assertTrue(method.invoke(null, "update 1", optionListEmpty) instanceof InvalidCommand);
+        } catch (ClassNotFoundException e) {
+            fail("No such class");
+        } catch (NoSuchMethodException e) {
+            fail("No such method");
+        } catch (InvocationTargetException e) {
+            fail(e.getMessage());
+        } catch (IllegalAccessException e) {
+            fail("No Access");
+        }
+    }
+
+    @Test
+    public void parseLinkCommandTest() {
+        try {
+            Class<?> parser = Class.forName("seedu.duke.task.parser.TaskCommandParseHelper");
+            Method method = parser.getDeclaredMethod("parseLinkCommand", String.class, ArrayList.class);
+            method.setAccessible(true);
+
+            ArrayList<Command.Option> optionListCorrect = new ArrayList<>(Arrays.asList(new Command.Option(
+                    "email", "1")));
+
+            ArrayList<Command.Option> optionListExtra = new ArrayList<>(Arrays.asList(new Command.Option(
+                    "email ", " 1"), new Command.Option("email", "2"), new Command.Option("email", "3 ")));
+
+            ArrayList<Command.Option> optionListEmpty = new ArrayList<>();
+
+            //positive cases
+            assertTrue(method.invoke(null, "link 1", optionListCorrect) instanceof TaskLinkCommand);
+            assertTrue(method.invoke(null, "link 1 ", optionListExtra) instanceof TaskLinkCommand);
+            assertTrue(method.invoke(null, "link  1", optionListExtra) instanceof TaskLinkCommand);
+            //no description
+            assertTrue(method.invoke(null, "link 1", optionListEmpty) instanceof TaskLinkCommand);
+
+            //negative cases
+            //no index
+//            assertTrue(method.invoke(null, "link ", optionListCorrect) instanceof InvalidCommand);
+            //no index or space
+//            assertTrue(method.invoke(null, "link", optionListEmpty) instanceof InvalidCommand);
+            //non-integer index
+//            assertTrue(method.invoke(null, "link 123abc", optionListCorrect) instanceof InvalidCommand);
+            //more than 1 integer
+//            assertTrue(method.invoke(null, "link 1 23", optionListCorrect) instanceof InvalidCommand);
         } catch (ClassNotFoundException e) {
             fail("No such class");
         } catch (NoSuchMethodException e) {

--- a/src/test/java/seedu/duke/TaskCommandParseHelperTest.java
+++ b/src/test/java/seedu/duke/TaskCommandParseHelperTest.java
@@ -12,6 +12,7 @@ import seedu.duke.task.command.TaskDoneCommand;
 import seedu.duke.task.command.TaskFindCommand;
 import seedu.duke.task.command.TaskReminderCommand;
 import seedu.duke.task.command.TaskSnoozeCommand;
+import seedu.duke.task.command.TaskUpdateCommand;
 import seedu.duke.task.entity.Task;
 import seedu.duke.task.parser.TaskCommandParseHelper;
 
@@ -419,5 +420,52 @@ public class TaskCommandParseHelperTest {
         assertEquals(null, TaskCommandParseHelper.checkTimeString("").getKey());
         assertEquals("1212", TaskCommandParseHelper.checkTimeString("1212 1212").getKey());
         assertEquals("1212", TaskCommandParseHelper.checkTimeString("1212").getKey());
+    }
+
+    @Test
+    public void parseUpdateCommandTest() {
+        try {
+            Class<?> parser = Class.forName("seedu.duke.task.parser.TaskCommandParseHelper");
+            Method method = parser.getDeclaredMethod("parseUpdateCommand", String.class, ArrayList.class);
+            method.setAccessible(true);
+
+            ArrayList<Command.Option> optionListCorrect = new ArrayList<>(Arrays.asList(new Command.Option(
+                    "doafter", "do after description")));
+
+            ArrayList<Command.Option> optionListExtra = new ArrayList<>(Arrays.asList(new Command.Option(
+                            "priority", " high"), new Command.Option("tag ", "123"),
+                    new Command.Option("doafter ", "description"), new Command.Option("time", "Mon"),
+                    new Command.Option("tag", "efg ")));
+
+            ArrayList<Command.Option> optionListExtra2 = new ArrayList<>(Arrays.asList(new Command.Option(
+                    "doafter", "do after description"), new Command.Option("msg", "something")));
+
+            //positive cases
+            assertTrue(method.invoke(null, "update 1", optionListCorrect) instanceof TaskUpdateCommand);
+            assertTrue(method.invoke(null, "update 1 ", optionListExtra) instanceof TaskUpdateCommand);
+            assertTrue(method.invoke(null, "update  1", optionListExtra) instanceof TaskUpdateCommand);
+            assertTrue(method.invoke(null, "update 1", optionListExtra2) instanceof TaskUpdateCommand);
+
+            //negative cases
+            //no index
+            assertTrue(method.invoke(null, "update ", optionListCorrect) instanceof InvalidCommand);
+            //no index or space
+            assertTrue(method.invoke(null, "update", optionListCorrect) instanceof InvalidCommand);
+            //non-integer index
+            assertTrue(method.invoke(null, "update 123abc", optionListCorrect) instanceof InvalidCommand);
+            //more than 1 integer
+            assertTrue(method.invoke(null, "update 1 23", optionListCorrect) instanceof InvalidCommand);
+            ArrayList<Command.Option> optionListEmpty = new ArrayList<>();
+            //no description
+            assertTrue(method.invoke(null, "update 1", optionListEmpty) instanceof InvalidCommand);
+        } catch (ClassNotFoundException e) {
+            fail("No such class");
+        } catch (NoSuchMethodException e) {
+            fail("No such method");
+        } catch (InvocationTargetException e) {
+            fail(e.getMessage());
+        } catch (IllegalAccessException e) {
+            fail("No Access");
+        }
     }
 }


### PR DESCRIPTION
EmailList class has two new methods: ```convertShaToSubject``` and ```convertShaToIndex```.
TaskLinkCommand will show first linked email when called.
TaskLinkCommand also now has a delete function: 
```link 2 -delete 2``` will delete the 2nd link in the list.

Additionally fixed a bug that does not allow all updateCommand info to be shown.
Added tests for UpdateCommand and LinkCommand